### PR TITLE
dont strip www from the host used in prometheus label

### DIFF
--- a/lua-init.conf
+++ b/lua-init.conf
@@ -37,7 +37,7 @@ init_by_lua_block {
 }
 
 log_by_lua_block {
-  local host = ngx.var.host:gsub("^www.", "")
+  local host = ngx.var.host
   metric_requests:inc(1, {host, ngx.var.status})
   metric_latency:observe(ngx.now() - ngx.req.start_time(), {host})
   metric_bytes:inc(tonumber(ngx.var.request_length))


### PR DESCRIPTION
This replacement turned out to be the source of confusion for pyton-shop's usage of LCRS via inproxy. 
The replacement itself was just copied from https://github.com/knyar/nginx-lua-prometheus/blob/master/README.md, so not really something we applied on purpose. I'd rather know if 2 different hostnames - with and without www at the start - are used than de-duping them at the source.

Just tested this branch's image with grafana-tooling works fine. Merging this to the 'base' 1.13.6.1-alpine branch first. From there we can merge this change into 1.13.6.1-proxy so inproxy can be updated and show the correct hostnames for LCRS traffic.