### PR TITLE
filter requests to health check path from prometheus metrics

### DIFF
--- a/lua-init.conf
+++ b/lua-init.conf
@@ -34,12 +34,16 @@ init_by_lua_block {
   else
     print("File "..filePath.." doesn\'t exist")
   end
+
+  healthCheckPath = os.getenv("HEALT_CHECK_PATH")
 }
 
 log_by_lua_block {
-  local host = ngx.var.host
-  metric_requests:inc(1, {host, ngx.var.status})
-  metric_latency:observe(ngx.now() - ngx.req.start_time(), {host})
-  metric_bytes:inc(tonumber(ngx.var.request_length))
-  metric_response_sizes:inc(tonumber(ngx.var.bytes_sent))
+  if ngx.var.request_uri ~= healthCheckPath then
+    local host = ngx.var.host
+    metric_requests:inc(1, {host, ngx.var.status})
+    metric_latency:observe(ngx.now() - ngx.req.start_time(), {host})
+    metric_bytes:inc(tonumber(ngx.var.request_length))
+    metric_response_sizes:inc(tonumber(ngx.var.bytes_sent))
+  end
 }


### PR DESCRIPTION
Since we started sending readiness checks through the normal request port - it's required by GCE ingress, which we use for IAP - our graphs are skewed by the large volume of readiness checks.