### PR TITLE
Fix upstream host

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,10 +99,10 @@ http {
   deny all;
 
   # set proxy defaults
-  proxy_set_header Host $host;
+  proxy_set_header Host $http_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Host $http_host;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_http_version 1.1;
   proxy_ssl_verify off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -99,10 +99,10 @@ http {
   deny all;
 
   # set proxy defaults
-  proxy_set_header Host $http_host;
+  proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Host $http_host;
+  proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_http_version 1.1;
   proxy_ssl_verify off;
@@ -168,6 +168,10 @@ http {
     location / {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
     
+      # headers that get redefined if not specified here
+      proxy_set_header Host $host;
+      proxy_set_header Connection $connection_upgrade;
+
       #cors
     }
   }
@@ -191,6 +195,10 @@ http {
     location / {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
 
+      # headers that get redefined if not specified here
+      proxy_set_header Host $host;
+      proxy_set_header Connection $connection_upgrade;
+
       #cors
     }
   }
@@ -205,6 +213,10 @@ http {
       error_log /dev/null;
 
       proxy_pass ${OFFLOAD_TO_PROTO}://backend${HEALT_CHECK_PATH};
+
+      # headers that get redefined if not specified here
+      proxy_set_header Host $host;
+      proxy_set_header Connection $connection_upgrade;
     }
   }
 


### PR DESCRIPTION
Since the upstream block got introduced to use keepalive the host header towards the backend changed to http://backend. This change fixes that.

According to http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header the `Host` and `Connection` headers are the only one reset if you define them in the block above (we set it in server, not in location).